### PR TITLE
EDGINREACH-42 [https://issues.folio.org/browse/EDGINREACH-42] - bump up edge-common-spring version and add headers for inn reach

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,3 @@
-## v2.0.0 2022-08-10
-
-* [EDGINREACH-42] (https://issues.folio.org/browse/EDGINREACH-42) - Bump up edge-common-spring version
-
 ## v1.1.0 IN-PROGRESS
 
 * [EDGINREACH-41] (https://issues.folio.org/browse/EDGINREACH-41) - Now supports users interface 15.3 16.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## v2.0.0 2022-08-10
+
+* [EDGINREACH-42] (https://issues.folio.org/browse/EDGINREACH-42) - Bump up edge-common-spring version
+
 ## v1.1.0 IN-PROGRESS
 
 * [EDGINREACH-41] (https://issues.folio.org/browse/EDGINREACH-41) - Now supports users interface 15.3 16.0

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <folio-spring-base.version>4.1.0</folio-spring-base.version>
-    <edge-common-spring.version>1.1.0</edge-common-spring.version>
+    <edge-common-spring.version>2.0.2</edge-common-spring.version>
     <openapi-generator.version>5.4.0</openapi-generator.version>
     <openapi.input.file>${project.basedir}/src/main/resources/swagger.api/edge-inn-reach.yaml</openapi.input.file>
     <mapstruct.version>1.4.2.Final</mapstruct.version>

--- a/src/main/java/org/folio/edge/security/filter/EdgeSecurityFilter.java
+++ b/src/main/java/org/folio/edge/security/filter/EdgeSecurityFilter.java
@@ -27,6 +27,9 @@ import org.folio.edgecommonspring.domain.entity.RequestWithHeaders;
 @RequiredArgsConstructor
 public class EdgeSecurityFilter extends OncePerRequestFilter {
 
+  public static final String X_TO_CODE = "x-to-code";
+  public static final String X_FROM_CODE = "x-from-code";
+  public static final String AUTHORIZATION_HEADER = "authorization";
   private final List<String> securityFilterIgnoreURIList;
   private final SecurityService securityService;
 
@@ -45,7 +48,16 @@ public class EdgeSecurityFilter extends OncePerRequestFilter {
     var requestWrapper = new RequestWithHeaders(request);
     requestWrapper.putHeader(TOKEN, okapiParameters.getOkapiToken());
     requestWrapper.putHeader(TENANT, okapiParameters.getTenantId());
-    requestWrapper.putHeader("authorization", request.getHeader(AUTHORIZATION));
+    /*
+      * added as edge-common-spring is removing / not capturing headers apart from x-okapi-token
+      * and as per d2ir specification inn-reach module require x-to-code and x-from-code
+      * and for edge to work it requires authorization header
+    */
+    requestWrapper.putHeader(AUTHORIZATION_HEADER, request.getHeader(AUTHORIZATION));
+    requestWrapper.putHeader(X_TO_CODE, request.getHeader(X_TO_CODE));
+    requestWrapper.putHeader(X_FROM_CODE, request.getHeader(X_FROM_CODE));
+
+    //end
 
     filterChain.doFilter(requestWrapper, response);
   }

--- a/src/main/java/org/folio/edge/security/filter/EdgeSecurityFilter.java
+++ b/src/main/java/org/folio/edge/security/filter/EdgeSecurityFilter.java
@@ -4,6 +4,8 @@ import static org.folio.edge.utils.CredentialsUtils.parseBasicAuth;
 import static org.folio.spring.integration.XOkapiHeaders.AUTHORIZATION;
 import static org.folio.spring.integration.XOkapiHeaders.TENANT;
 import static org.folio.spring.integration.XOkapiHeaders.TOKEN;
+import static org.folio.edge.external.InnReachHttpHeaders.X_FROM_CODE;
+import static org.folio.edge.external.InnReachHttpHeaders.X_TO_CODE;
 
 import java.io.IOException;
 import java.util.List;
@@ -27,9 +29,6 @@ import org.folio.edgecommonspring.domain.entity.RequestWithHeaders;
 @RequiredArgsConstructor
 public class EdgeSecurityFilter extends OncePerRequestFilter {
 
-  public static final String X_TO_CODE = "x-to-code";
-  public static final String X_FROM_CODE = "x-from-code";
-  public static final String AUTHORIZATION_HEADER = "authorization";
   private final List<String> securityFilterIgnoreURIList;
   private final SecurityService securityService;
 
@@ -53,7 +52,7 @@ public class EdgeSecurityFilter extends OncePerRequestFilter {
       * and as per d2ir specification inn-reach module require x-to-code and x-from-code
       * and for edge to work it requires authorization header
     */
-    requestWrapper.putHeader(AUTHORIZATION_HEADER, request.getHeader(AUTHORIZATION));
+    requestWrapper.putHeader(AUTHORIZATION.toLowerCase(), request.getHeader(AUTHORIZATION));
     requestWrapper.putHeader(X_TO_CODE, request.getHeader(X_TO_CODE));
     requestWrapper.putHeader(X_FROM_CODE, request.getHeader(X_FROM_CODE));
 

--- a/src/main/java/org/folio/edge/security/filter/EdgeSecurityFilter.java
+++ b/src/main/java/org/folio/edge/security/filter/EdgeSecurityFilter.java
@@ -45,6 +45,7 @@ public class EdgeSecurityFilter extends OncePerRequestFilter {
     var requestWrapper = new RequestWithHeaders(request);
     requestWrapper.putHeader(TOKEN, okapiParameters.getOkapiToken());
     requestWrapper.putHeader(TENANT, okapiParameters.getTenantId());
+    requestWrapper.putHeader("authorization", request.getHeader(AUTHORIZATION));
 
     filterChain.doFilter(requestWrapper, response);
   }


### PR DESCRIPTION
EDGINREACH-42 [https://issues.folio.org/browse/EDGINREACH-42] - bump up edge-common-spring version

## Purpose
To bump up edge-common-spring version from 1.1.0 to 2.0.2. 
A bit of code change was needed in the EdgeSecurityFilter -  added 3 headers as edge-common-spring is removing / not capturing headers apart from x-okapi-token and as per d2ir specification inn-reach module require x-to-code and x-from-code and for edge to work it requires authorization header.

## Approach
Changed the code and tested with Karate and Java test classes.

## Screenshots
![image](https://user-images.githubusercontent.com/34331959/183852430-7bee4fbf-9e87-43e3-9f96-17a6d2865ce3.png)
![image](https://user-images.githubusercontent.com/34331959/183852564-f899dab2-2541-409b-b8e3-e525b440acf4.png)
![image](https://user-images.githubusercontent.com/34331959/183863735-40d81168-a6dd-4767-be4d-41f90cfa74ed.png)
