### PR TITLE
Tmp release 2.0.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
-## v1.1.0 IN-PROGRESS
+## v2.0.0 2022-08-16
 
+### Stories
+
+* [EDGINREACH-35] (https://issues.folio.org/browse/EDGINREACH-35) - edge-inn-reach Spring 2.7 upgrade for Morning Glory 2022 R2
 * [EDGINREACH-41] (https://issues.folio.org/browse/EDGINREACH-41) - Now supports users interface 15.3 16.0
+* [EDGINREACH-42] (https://issues.folio.org/browse/EDGINREACH-42) - bump up edge-common-spring version
 
 ## v1.0.5 2022-05-30
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>org.folio</groupId>
   <artifactId>edge-inn-reach</artifactId>
-  <version>1.0.6-SNAPSHOT</version>
+  <version>2.0.0</version>
   <name>edge-inn-reach</name>
   <description>INN-REACH system Edge API module</description>
 
@@ -297,7 +297,7 @@
     <url>https://github.com/folio-org/${project.artifactId}</url>
     <connection>scm:git:git://github.com/folio-org/${project.artifactId}.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/${project.artifactId}.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v2.0.0</tag>
   </scm>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>org.folio</groupId>
   <artifactId>edge-inn-reach</artifactId>
-  <version>2.0.0</version>
+  <version>2.0.1-SNAPSHOT</version>
   <name>edge-inn-reach</name>
   <description>INN-REACH system Edge API module</description>
 
@@ -297,7 +297,7 @@
     <url>https://github.com/folio-org/${project.artifactId}</url>
     <connection>scm:git:git://github.com/folio-org/${project.artifactId}.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/${project.artifactId}.git</developerConnection>
-    <tag>v2.0.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <repositories>


### PR DESCRIPTION
## v2.0.0 2022-08-16

### Stories

* [EDGINREACH-35] (https://issues.folio.org/browse/EDGINREACH-35) - edge-inn-reach Spring 2.7 upgrade for Morning Glory 2022 R2
* [EDGINREACH-41] (https://issues.folio.org/browse/EDGINREACH-41) - Now supports users interface 15.3 16.0
* [EDGINREACH-42] (https://issues.folio.org/browse/EDGINREACH-42) - bump up edge-common-spring version

Jenkins build screen shot (highlighted in yellow) -
![image](https://user-images.githubusercontent.com/34331959/184818981-e141d574-f8a1-4f8a-b319-ba72df1dd386.png)
