### PR TITLE
Tmp release 2.0.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
-## v1.1.0 IN-PROGRESS
+## v2.0.1 2022-08-16
 
-* [EDGINREACH-41] (https://issues.folio.org/browse/EDGINREACH-41) - Now supports users interface 15.3 16.0
+### Stories
+* [EDGINREACH-35] (https://issues.folio.org/browse/EDGINREACH-35) - edge-inn-reach Spring 2.7 upgrade for Morning Glory 2022 R2
+* [EDGINREACH-42] (https://issues.folio.org/browse/EDGINREACH-42) - bump up edge-common-spring version
 
 ## v1.0.5 2022-05-30
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -9,7 +9,7 @@
     },
     {
       "id": "users",
-      "version": "15.3 16.0"
+      "version": "15.3"
     },
     {
       "id": "permissions",

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>org.folio</groupId>
   <artifactId>edge-inn-reach</artifactId>
-  <version>1.0.6-SNAPSHOT</version>
+  <version>2.0.1</version>
   <name>edge-inn-reach</name>
   <description>INN-REACH system Edge API module</description>
 
@@ -297,7 +297,7 @@
     <url>https://github.com/folio-org/${project.artifactId}</url>
     <connection>scm:git:git://github.com/folio-org/${project.artifactId}.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/${project.artifactId}.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v2.0.1</tag>
   </scm>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>org.folio</groupId>
   <artifactId>edge-inn-reach</artifactId>
-  <version>2.0.1</version>
+  <version>2.0.2-SNAPSHOT</version>
   <name>edge-inn-reach</name>
   <description>INN-REACH system Edge API module</description>
 
@@ -297,7 +297,7 @@
     <url>https://github.com/folio-org/${project.artifactId}</url>
     <connection>scm:git:git://github.com/folio-org/${project.artifactId}.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/${project.artifactId}.git</developerConnection>
-    <tag>v2.0.1</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <repositories>


### PR DESCRIPTION
## v2.0.1 2022-08-16

### Stories
* [EDGINREACH-35] (https://issues.folio.org/browse/EDGINREACH-35) - edge-inn-reach Spring 2.7 upgrade for Morning Glory 2022 R2
* [EDGINREACH-42] (https://issues.folio.org/browse/EDGINREACH-42) - bump up edge-common-spring version

Reverted the code of EDGINREACH-41 as it is Morning Glory release.

Jenkins build passed for v2.0.1 - 
![image](https://user-images.githubusercontent.com/34331959/184855137-bc46049d-b12f-49b8-b441-10cba510eab6.png)
