### PR TITLE
MODINREACH-322 : Module Version Upgrade (for Nolana)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.7.0</version>
+    <version>2.7.3</version>
     <relativePath />
   </parent>
   <groupId>org.folio</groupId>
@@ -24,7 +24,7 @@
     <java.version>11</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <folio-spring-base.version>4.1.0</folio-spring-base.version>
+    <folio-spring-base.version>5.0.1</folio-spring-base.version>
     <edge-common-spring.version>2.0.2</edge-common-spring.version>
     <openapi-generator.version>5.4.0</openapi-generator.version>
     <openapi.input.file>${project.basedir}/src/main/resources/swagger.api/edge-inn-reach.yaml</openapi.input.file>
@@ -33,7 +33,8 @@
     <wiremock.version>2.28.1</wiremock.version>
     <junit-extensions.version>2.5.0</junit-extensions.version>
     <mockito.version>4.6.1</mockito.version>
-    <log4j2.version>2.17.0</log4j2.version>
+    <log4j2.version>2.19.0</log4j2.version>
+    <micrometer-core.version>1.9.4</micrometer-core.version>
     <argLine />
     <sonar.exclusions>
       src/main/java/org/folio/edge/EdgeInnReachApplication.java,
@@ -61,6 +62,10 @@
         <exclusion>
           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-starter-logging</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.micrometer</groupId>
+          <artifactId>micrometer-core</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -148,7 +153,11 @@
       <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+      <version>${micrometer-core.version}</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <java.version>11</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <folio-spring-base.version>5.0.1</folio-spring-base.version>
+    <folio-spring-base.version>5.0.2</folio-spring-base.version>
     <edge-common-spring.version>2.0.2</edge-common-spring.version>
     <openapi-generator.version>5.4.0</openapi-generator.version>
     <openapi.input.file>${project.basedir}/src/main/resources/swagger.api/edge-inn-reach.yaml</openapi.input.file>
@@ -34,7 +34,7 @@
     <junit-extensions.version>2.5.0</junit-extensions.version>
     <mockito.version>4.6.1</mockito.version>
     <log4j2.version>2.19.0</log4j2.version>
-    <micrometer-core.version>1.9.4</micrometer-core.version>
+    <micrometer.version>1.9.4</micrometer.version>
     <argLine />
     <sonar.exclusions>
       src/main/java/org/folio/edge/EdgeInnReachApplication.java,
@@ -156,7 +156,7 @@
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
-      <version>${micrometer-core.version}</version>
+      <version>${micrometer.version}</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
[MODINREACH-322](https://issues.folio.org/browse/MODINREACH-322)
Module Version Upgrade (for Nolana)

<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODQM-3 - Implement GET records-editor/marc-records/{id} endpoint

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
Below is a bump of module version upgrade (for Nolana) and as of now I think for inn-reach and sip2 we are not having release for Nolana, but if there is a release we want to push for Nolana like sip2 then do we bump the versions (Vert.x 4.3.4, micrometer 1.9.4, log4j 2.19.0, okapi 4.14.5), As per me maybe we should and then release the module for Nolana.. your thoughts please if we need (or not) bump these dependencies version.

 

Epic jira for Nolana - https://issues.folio.org/browse/FOLREL-553?src=confmacro -- These are the version upgrade needed Vert.x 4.3.4, micrometer 1.9.4, log4j 2.19.0, okapi 4.14.5, Update folio-spring-base from v2.. or v3.. to latest v5...



## Approach
 Version Upgrade changes are done and executed in all build test cases : **Module** : **edge-inn-reach**

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.