### PR TITLE
EDGINREACH-52: apk upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM folioci/alpine-jre-openjdk17:latest
 
+# Install latest patch versions of packages: https://pythonspeed.com/articles/security-updates-in-docker/
+USER root
+RUN apk upgrade --no-cache
+USER folio
+
 # Copy your fat jar to the container
 ENV APP_FILE edge-inn-reach-fat.jar
 


### PR DESCRIPTION
Add "apk upgrade" to Dockerfile to upgrade Alpine packages to available patch versions.

This is a security best practice:

https://github.com/folio-org/folio-tools/tree/master/folio-java-docker/openjdk17#sample-module-dockerfile https://dev.folio.org/guides/best-practices-dockerfiles/