### PR TITLE
EDGINREACH-69: edge-common-spring 2.4.4, Spring Boot 3.2.6 fixing vulns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.3</version>
+    <version>3.2.6</version>
     <relativePath />
   </parent>
   <groupId>org.folio</groupId>
@@ -25,7 +25,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <folio-spring-base.version>8.1.0</folio-spring-base.version>
-    <edge-common-spring.version>2.4.3</edge-common-spring.version>
+    <edge-common-spring.version>2.4.4</edge-common-spring.version>
 
     <openapi-generator.version>7.3.0</openapi-generator.version>
     <openapi.input.file>${project.basedir}/src/main/resources/swagger.api/edge-inn-reach.yaml</openapi.input.file>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/EDGINREACH-69

Upgrade edge-common-spring from 2.4.3 to 2.4.4.

Upgrade Spring Boot from 3.2.3 to 3.2.6.

The Spring Boot upgrade indirectly upgrades spring-web from 6.1.4 to 6.1.8 fixing UriComponentsBuilder Open Redirect:

* https://spring.io/security/cve-2024-22259
* https://spring.io/security/cve-2024-22262

The Spring Boot upgrade indirectly upgrades netty-codec-http from 4.1.107.Final to 4.1.110.Final fixing form POST OOM:

* https://github.com/netty/netty/security/advisories/GHSA-5jpm-x58v-624v = CVE-2024-29025