### PR TITLE
bump up edge-common-spring to v2.4.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <folio-spring-base.version>8.1.0</folio-spring-base.version>
-    <edge-common-spring.version>2.4.4</edge-common-spring.version>
+    <edge-common-spring.version>2.4.5</edge-common-spring.version>
 
     <openapi-generator.version>7.3.0</openapi-generator.version>
     <openapi.input.file>${project.basedir}/src/main/resources/swagger.api/edge-inn-reach.yaml</openapi.input.file>
@@ -52,7 +52,6 @@
       src/main/java/org/folio/edge/domain/dto/**
     </sonar.exclusions>
 
-    <folio-tls-utils.version>1.5.0</folio-tls-utils.version>
   </properties>
 
   <dependencies>
@@ -156,12 +155,6 @@
       <groupId>io.jsonwebtoken</groupId>
       <artifactId>jjwt</artifactId>
       <version>${io.jsonwebtoken.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.folio</groupId>
-      <artifactId>folio-tls-utils</artifactId>
-      <version>${folio-tls-utils.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
bump up edge-common-spring to v2.4.5: AwsParamStore to support FIPS-approved crypto modules
