### PR TITLE
EDGINREACH-86: Add config file for dependabot and template for pull request

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+### Purpose
+_Describe the purpose of this pull request. Why is this change necessary? What problem does it solve?_
+
+### Approach
+_How does this change fulfill the purpose? Provide a high-level overview of the technical approach taken to address the problem._
+
+### Changes Checklist
+- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
+- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
+- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
+- [ ] **Interface Dependencies**: Document added or removed dependencies.
+- [ ] **Permissions**: Document any changes to permissions.
+- [ ] **Logging**: Confirm that logging is appropriately handled.
+- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
+- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
+- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
+- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.
+
+### Related Issues
+[EDGINREACH-XXX](https://folio-org.atlassian.net/browse/EDGINREACH-XXX)
+_List any Jira issues related to this pull request._
+
+### Learning and Resources (if applicable)
+_Discuss any research conducted during the development of this pull request. Include links to relevant blog posts, patterns, libraries, or addons that were used to solve the problem._
+
+### Screenshots (if applicable)
+_If this pull request involves any visual changes or new features, consider including screenshots or GIFs to illustrate the changes._

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope
+    groups:
+      dev-deps:
+        dependency-type: "development"
+      prod-deps:
+        dependency-type: "production"


### PR DESCRIPTION
## Purpose
- to have in place the process for automation of the updates of dependent modules
- to have standardized approach for all the Pull Requests created for the modules of volaris team

## Approach
- add dependabot.yml config file
- add PULL_REQUEST_TEMPLATE.md file

### TODOS and Open Questions

## Learning
[EDGEINREACH-86](https://folio-org.atlassian.net/browse/EDGINREACH-86)

## Pre-Merge Checklist:
 Before merging this PR, please go through the following list and take appropriate actions.

 - Does this PR meet or exceed the expected quality standards?
   - [ ] Code coverage on new code is 80% or greater
   - [ ] Duplications on new code is 3% or less
   - [ ] There are no major code smells or security issues
 - Does this introduce breaking changes?
   - [ ] Were any API paths or methods changed, added or removed?
   - [ ] Were there any schema changes?
   - [ ] Did any of the interface versions change?
   - [ ] Were permissions changed, added, or removed?
   - [ ] Are there new interface dependencies?
   - [ ] There are no breaking changes in this PR.
   - [ ] Check logging.

 If there are breaking changes, please **STOP** and consider the following:

 - What other modules will these changes impact?
 - Do JIRAs exist to update the impacted modules?
   - [ ] If not, please create them
   - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
   - [ ] Do they have all they appropriate links to blocked/related issues?
 - Are the JIRAs under active development?
   - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
 - Do PRs exist for these changes?
   - [ ] If so, have they been approved?

 Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

 While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
