### PR TITLE
EDGINREACH-98 Restore Accept/Content-Type header forwarding to mod-inn-reach D2IR endpoints

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+## v4.1.0-SNAPSHOT In progress
+
+### Bug fixes
+
+
+
 ## v4.0.0 2026-04-17
 
 ### Breaking changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 ## v4.1.0-SNAPSHOT In progress
 
 ### Bug fixes
-
+* Restore Accept/Content-Type header forwarding to mod-inn-reach D2IR endpoints ([EDGINREACH-98](https://folio-org.atlassian.net/browse/EDGINREACH-98))
 
 
 ## v4.0.0 2026-04-17

--- a/src/main/java/org/folio/edge/client/InnReachClient.java
+++ b/src/main/java/org/folio/edge/client/InnReachClient.java
@@ -13,16 +13,16 @@ import org.springframework.web.service.annotation.HttpExchange;
 import org.springframework.web.service.annotation.PostExchange;
 import org.springframework.web.service.annotation.PutExchange;
 
-@HttpExchange(contentType = MediaType.APPLICATION_JSON_VALUE)
+@HttpExchange
 public interface InnReachClient {
 
   @GetExchange
   ResponseEntity<?> getCall(URI modInnReachURI, @RequestHeader Map<String, String> headers);
 
-  @PostExchange
+  @PostExchange(contentType = MediaType.APPLICATION_JSON_VALUE, accept = MediaType.APPLICATION_JSON_VALUE)
   ResponseEntity<?> postCall(URI modInnReachURI, @RequestBody String requestBody, @RequestHeader Map<String, String> headers);
 
-  @PutExchange
+  @PutExchange(contentType = MediaType.APPLICATION_JSON_VALUE, accept = MediaType.APPLICATION_JSON_VALUE)
   ResponseEntity<?> putCall(URI modInnReachURI, @RequestBody String requestBody, @RequestHeader Map<String, String> headers);
 
   @DeleteExchange

--- a/src/test/java/org/folio/edge/controller/InnReachHeaderForwardingTest.java
+++ b/src/test/java/org/folio/edge/controller/InnReachHeaderForwardingTest.java
@@ -1,0 +1,164 @@
+package org.folio.edge.controller;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.springframework.http.HttpHeaders.ACCEPT;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import static org.folio.edge.api.utils.Constants.X_OKAPI_TOKEN;
+import static org.folio.edge.fixture.InnReachFixture.createInnReachHttpHeaders;
+import static org.folio.edge.util.TestUtil.TEST_TOKEN;
+import static org.folio.edge.util.TestUtil.readFileContentAsString;
+
+import java.time.Instant;
+
+import javax.crypto.SecretKey;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.folio.edgecommonspring.security.SecurityManagerService;
+import org.folio.spring.model.UserToken;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import org.folio.edge.controller.base.BaseControllerTest;
+import org.folio.edge.domain.dto.JwtAccessToken;
+import org.folio.edge.domain.service.AccessTokenService;
+import org.folio.edgecommonspring.domain.entity.ConnectionSystemParameters;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+class InnReachHeaderForwardingTest extends BaseControllerTest {
+
+  private static final String EDGE_BASE_URI = "/innreach/v2";
+  private static final String TRACKING_ID = "tracking01";
+  private static final String CENTRAL_CODE = "d2irm";
+
+  private static final String MOD_PATRON_HOLD_URI =
+    "/inn-reach/d2ir/circ/patronhold/" + TRACKING_ID + "/" + CENTRAL_CODE;
+  private static final String MOD_ITEM_SHIPPED_URI =
+    "/inn-reach/d2ir/circ/itemshipped/" + TRACKING_ID + "/" + CENTRAL_CODE;
+
+  private static final String TEST_JWT_SIGNATURE_SECRET = "test-jwt-secret-for-hs256-algo!!";
+  private static final SecretKey TEST_JWT_SECRET_KEY = Keys.hmacShaKeyFor(
+    TEST_JWT_SIGNATURE_SECRET.getBytes()
+  );
+
+  private static final String JWT_TOKEN_STRING =
+    readFileContentAsString("/jwt/token/jwt-with-authorities.txt");
+  private static final String AUTH_TOKEN_VALUE = "Bearer " + JWT_TOKEN_STRING;
+
+  @MockitoBean
+  private AccessTokenService<JwtAccessToken, Jws<Claims>> accessTokenService;
+
+  @MockitoBean
+  private SecurityManagerService securityManagerService;
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setUp() {
+    var jwt = Jwts.parser()
+      .verifyWith(TEST_JWT_SECRET_KEY)
+      .build()
+      .parseSignedClaims(JWT_TOKEN_STRING);
+
+    when(accessTokenService.verifyAccessToken(any())).thenReturn(jwt);
+    when(securityManagerService.getParamsWithToken(any())).thenReturn(
+      new ConnectionSystemParameters()
+        .withOkapiToken(new UserToken("token", Instant.MAX))
+        .withTenantId("test"));
+
+    wireMock.stubFor(WireMock.post(urlEqualTo("/authn/login"))
+      .willReturn(aResponse()
+        .withStatus(200)
+        .withHeader(X_OKAPI_TOKEN, TEST_TOKEN)));
+  }
+
+  @Test
+  void shouldForwardAcceptAndContentTypeOnPatronHoldPost() throws Exception {
+    var httpHeaders = createInnReachHttpHeaders();
+    httpHeaders.set(AUTHORIZATION, AUTH_TOKEN_VALUE);
+
+    wireMock.stubFor(WireMock.post(urlEqualTo(MOD_PATRON_HOLD_URI))
+      .willReturn(aResponse()
+        .withStatus(200)
+        .withBody("{}")
+        .withHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)));
+
+    mockMvc.perform(post(EDGE_BASE_URI + "/circ/patronhold/" + TRACKING_ID + "/" + CENTRAL_CODE)
+        .headers(httpHeaders)
+        .contentType(MediaType.APPLICATION_JSON)
+        .accept(MediaType.APPLICATION_JSON)
+        .content("{}"))
+      .andExpect(status().isOk());
+
+    wireMock.verify(postRequestedFor(urlEqualTo(MOD_PATRON_HOLD_URI))
+      .withHeader(ACCEPT, equalTo(APPLICATION_JSON_VALUE))
+      .withHeader(CONTENT_TYPE, containing(APPLICATION_JSON_VALUE)));
+  }
+
+  @Test
+  void shouldForwardAcceptAndContentTypeOnItemShippedPut() throws Exception {
+    var httpHeaders = createInnReachHttpHeaders();
+    httpHeaders.set(AUTHORIZATION, AUTH_TOKEN_VALUE);
+
+    wireMock.stubFor(WireMock.put(urlEqualTo(MOD_ITEM_SHIPPED_URI))
+      .willReturn(aResponse()
+        .withStatus(200)
+        .withBody("{}")
+        .withHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)));
+
+    mockMvc.perform(put(EDGE_BASE_URI + "/circ/itemshipped/" + TRACKING_ID + "/" + CENTRAL_CODE)
+        .headers(httpHeaders)
+        .contentType(MediaType.APPLICATION_JSON)
+        .accept(MediaType.APPLICATION_JSON)
+        .content("{}"))
+      .andExpect(status().isOk());
+
+    wireMock.verify(putRequestedFor(urlEqualTo(MOD_ITEM_SHIPPED_URI))
+      .withHeader(ACCEPT, equalTo(APPLICATION_JSON_VALUE))
+      .withHeader(CONTENT_TYPE, containing(APPLICATION_JSON_VALUE)));
+  }
+
+  @Test
+  void shouldSendAcceptHeaderEvenWhenNotExplicitlySetByClient() throws Exception {
+    // Client sends no Accept header — InnReachClient's @HttpExchange(accept=APPLICATION_JSON_VALUE)
+    // must still ensure Accept: application/json reaches mod-inn-reach
+    var httpHeaders = createInnReachHttpHeaders();
+    httpHeaders.set(AUTHORIZATION, AUTH_TOKEN_VALUE);
+
+    wireMock.stubFor(WireMock.post(urlEqualTo(MOD_PATRON_HOLD_URI))
+      .willReturn(aResponse()
+        .withStatus(200)
+        .withBody("{}")
+        .withHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)));
+
+    mockMvc.perform(post(EDGE_BASE_URI + "/circ/patronhold/" + TRACKING_ID + "/" + CENTRAL_CODE)
+        .headers(httpHeaders)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content("{}"))
+      .andExpect(status().isOk());
+
+    wireMock.verify(postRequestedFor(urlEqualTo(MOD_PATRON_HOLD_URI))
+      .withHeader(ACCEPT, containing(APPLICATION_JSON_VALUE)));
+  }
+}

--- a/src/test/java/org/folio/edge/controller/base/BaseControllerTest.java
+++ b/src/test/java/org/folio/edge/controller/base/BaseControllerTest.java
@@ -33,14 +33,18 @@ public class BaseControllerTest {
 
   @BeforeAll
   static void beforeAll() {
-    wireMock.start();
-    log.info("Wire mock started");
+    if (!wireMock.isRunning()) {
+      wireMock.start();
+    }
+
+    log.info("Wire mock started on port {}", wireMock.port());
   }
 
   @AfterAll
   static void afterAll() {
-    wireMock.stop();
-    log.info("Wire mock stopped");
+    // WireMock is intentionally kept running between test classes that share the same
+    // Spring context (same mock beans). Stopping it here would invalidate the cached
+    // context for subsequent classes. Stubs are reset per test in tearDown().
   }
 
   @AfterEach


### PR DESCRIPTION
### Purpose
Fix D2IR circulation calls (patronhold, itemshipped, etc.) returning {"status":"failed","reason":"Required request header 'Accept' for method parameter type String is not present"} on the edge-etesting environment.

### Approach
When migrating from Feign to Spring @HttpExchange in EDGINREACH-93, the produces/consumes attributes on @PostMapping/@PutMapping were dropped. Feign was automatically injecting Accept: application/json and Content-Type: application/json from those attributes on every outbound call to mod-inn-reach — the new @HttpExchange client did not. The fix restores equivalent behaviour by adding accept and contentType attributes directly on @PostExchange and @PutExchange methods in InnReachClient and InnReachAuthClient.

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[EDGINREACH-98](https://folio-org.atlassian.net/browse/EDGINREACH-98)

### Learning and Resources (if applicable)
_Discuss any research conducted during the development of this pull request. Include links to relevant blog posts, patterns, libraries, or addons that were used to solve the problem._

### Screenshots (if applicable)
_If this pull request involves any visual changes or new features, consider including screenshots or GIFs to illustrate the changes._
