### PR TITLE
EDGINREACH-98: Fix JSON body double-encoding in D2IR proxy calls

### DIFF
--- a/src/main/java/org/folio/edge/config/ExchangeClientConfiguration.java
+++ b/src/main/java/org/folio/edge/config/ExchangeClientConfiguration.java
@@ -1,10 +1,14 @@
 package org.folio.edge.config;
 
+import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.function.UnaryOperator;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.web.client.RestClient;
 
@@ -13,6 +17,14 @@ public class ExchangeClientConfiguration {
 
   @Bean("edgeRestClientCustomizer")
   public UnaryOperator<RestClient.Builder> edgeRestClientCustomizer() {
+    var stringConverter = new StringHttpMessageConverter(StandardCharsets.UTF_8);
+    stringConverter.setSupportedMediaTypes(List.of(
+      MediaType.TEXT_PLAIN,
+      MediaType.APPLICATION_JSON,
+      new MediaType("application", "*+json"),
+      MediaType.ALL
+    ));
+
     return restClientBuilder ->
       restClientBuilder.defaultStatusHandler(
           status -> status.value() == HttpStatus.UNAUTHORIZED.value(), (request, response) -> {

--- a/src/main/java/org/folio/edge/config/ExchangeClientConfiguration.java
+++ b/src/main/java/org/folio/edge/config/ExchangeClientConfiguration.java
@@ -1,14 +1,10 @@
 package org.folio.edge.config;
 
-import java.nio.charset.StandardCharsets;
-import java.util.List;
 import java.util.function.UnaryOperator;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.web.client.RestClient;
 
@@ -17,16 +13,13 @@ public class ExchangeClientConfiguration {
 
   @Bean("edgeRestClientCustomizer")
   public UnaryOperator<RestClient.Builder> edgeRestClientCustomizer() {
-    var stringConverter = new StringHttpMessageConverter(StandardCharsets.UTF_8);
-    stringConverter.setSupportedMediaTypes(List.of(
-      MediaType.TEXT_PLAIN,
-      MediaType.APPLICATION_JSON,
-      new MediaType("application", "*+json"),
-      MediaType.ALL
-    ));
-
     return restClientBuilder ->
-      restClientBuilder.defaultStatusHandler(
+      restClientBuilder
+        .configureMessageConverters(builder -> builder
+          .registerDefaults()
+          .configureMessageConvertersList(converters -> converters.addFirst(new RawJsonStringHttpMessageConverter()))
+        )
+        .defaultStatusHandler(
           status -> status.value() == HttpStatus.UNAUTHORIZED.value(), (request, response) -> {
             throw new BadCredentialsException("Token authentication failed");
           });

--- a/src/main/java/org/folio/edge/config/RawJsonStringHttpMessageConverter.java
+++ b/src/main/java/org/folio/edge/config/RawJsonStringHttpMessageConverter.java
@@ -1,0 +1,80 @@
+package org.folio.edge.config;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.core.ResolvableType;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+import org.springframework.http.converter.SmartHttpMessageConverter;
+
+/**
+ * A {@link SmartHttpMessageConverter} that reads and writes {@code application/json} bodies as raw
+ * {@link String} without any Jackson deserialization/re-serialization. This ensures the JSON
+ * body is forwarded exactly as received from the caller.
+ *
+ * <p>Must be registered before Jackson converters so that {@code @HttpExchange} proxy methods
+ * with a {@code String} body do not get double-encoded by Jackson.</p>
+ */
+public class RawJsonStringHttpMessageConverter implements SmartHttpMessageConverter<String> {
+
+  private static final List<MediaType> SUPPORTED_MEDIA_TYPES =
+    List.of(MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN, MediaType.ALL);
+
+  @Override
+  public boolean canRead(ResolvableType type, MediaType mediaType) {
+    return String.class == type.toClass() && isSupportedMediaType(mediaType);
+  }
+
+  @Override
+  public boolean canWrite(ResolvableType targetType, Class<?> valueClass, MediaType mediaType) {
+    return String.class == valueClass && isSupportedMediaType(mediaType);
+  }
+
+  @Override
+  public List<MediaType> getSupportedMediaTypes() {
+    return SUPPORTED_MEDIA_TYPES;
+  }
+
+  @Override
+  public String read(ResolvableType type, HttpInputMessage inputMessage,
+                     Map<String, Object> hints) throws IOException, HttpMessageNotReadableException {
+    Charset charset = getCharset(inputMessage);
+    return new String(inputMessage.getBody().readAllBytes(), charset);
+  }
+
+  @Override
+  public void write(String value, ResolvableType type, MediaType contentType,
+                    HttpOutputMessage outputMessage, Map<String, Object> hints)
+    throws IOException, HttpMessageNotWritableException {
+    Charset charset = (contentType != null && contentType.getCharset() != null)
+      ? contentType.getCharset() : StandardCharsets.UTF_8;
+    outputMessage.getBody().write(value.getBytes(charset));
+  }
+
+  private boolean isSupportedMediaType(MediaType mediaType) {
+    if (mediaType == null) {
+      return true;
+    }
+    for (MediaType supported : SUPPORTED_MEDIA_TYPES) {
+      if (supported.includes(mediaType)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private Charset getCharset(HttpInputMessage inputMessage) {
+    MediaType contentType = inputMessage.getHeaders().getContentType();
+    if (contentType != null && contentType.getCharset() != null) {
+      return contentType.getCharset();
+    }
+    return StandardCharsets.UTF_8;
+  }
+}

--- a/src/test/java/org/folio/edge/config/RawJsonStringHttpMessageConverterTest.java
+++ b/src/test/java/org/folio/edge/config/RawJsonStringHttpMessageConverterTest.java
@@ -1,0 +1,181 @@
+package org.folio.edge.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.ResolvableType;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+
+@ExtendWith(MockitoExtension.class)
+class RawJsonStringHttpMessageConverterTest {
+
+  private final RawJsonStringHttpMessageConverter converter = new RawJsonStringHttpMessageConverter();
+
+  @Mock
+  private HttpInputMessage inputMessage;
+
+  @Mock
+  private HttpOutputMessage outputMessage;
+
+  @Test
+  void canRead_withStringTypeAndJsonMediaType_returnsTrue() {
+    assertTrue(converter.canRead(ResolvableType.forClass(String.class), MediaType.APPLICATION_JSON));
+  }
+
+  @Test
+  void canRead_withStringTypeAndTextPlainMediaType_returnsTrue() {
+    assertTrue(converter.canRead(ResolvableType.forClass(String.class), MediaType.TEXT_PLAIN));
+  }
+
+  @Test
+  void canRead_withStringTypeAndNullMediaType_returnsTrue() {
+    assertTrue(converter.canRead(ResolvableType.forClass(String.class), null));
+  }
+
+  @Test
+  void canRead_withNonStringType_returnsFalse() {
+    assertFalse(converter.canRead(ResolvableType.forClass(Integer.class), MediaType.APPLICATION_JSON));
+  }
+
+  @Test
+  void canRead_withStringTypeAndXmlMediaType_returnsTrueBecauseAllIsSupported() {
+    assertTrue(converter.canRead(ResolvableType.forClass(String.class), MediaType.APPLICATION_XML));
+  }
+
+  @Test
+  void canWrite_withStringClassAndJsonMediaType_returnsTrue() {
+    assertTrue(converter.canWrite(ResolvableType.forClass(String.class), String.class, MediaType.APPLICATION_JSON));
+  }
+
+  @Test
+  void canWrite_withNonStringClass_returnsFalse() {
+    assertFalse(converter.canWrite(ResolvableType.forClass(Integer.class), Integer.class, MediaType.APPLICATION_JSON));
+  }
+
+  @Test
+  void canWrite_withNullMediaType_returnsTrue() {
+    assertTrue(converter.canWrite(ResolvableType.forClass(String.class), String.class, null));
+  }
+
+  @Test
+  void getSupportedMediaTypes_returnsJsonTextPlainAndAll() {
+    var types = converter.getSupportedMediaTypes();
+    assertEquals(3, types.size());
+    assertTrue(types.contains(MediaType.APPLICATION_JSON));
+    assertTrue(types.contains(MediaType.TEXT_PLAIN));
+    assertTrue(types.contains(MediaType.ALL));
+  }
+
+  @Test
+  void read_withUtf8Content_returnsExactString() throws IOException {
+    String json = "{\"key\":\"value\"}";
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    when(inputMessage.getHeaders()).thenReturn(headers);
+    when(inputMessage.getBody()).thenReturn(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)));
+
+    String result = converter.read(ResolvableType.forClass(String.class), inputMessage, Map.of());
+
+    assertEquals(json, result);
+  }
+
+  @Test
+  void read_withExplicitCharsetInContentType_usesSpecifiedCharset() throws IOException {
+    String json = "{\"key\":\"ñ\"}";
+    MediaType mediaType = new MediaType("application", "json", StandardCharsets.ISO_8859_1);
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(mediaType);
+    when(inputMessage.getHeaders()).thenReturn(headers);
+    when(inputMessage.getBody()).thenReturn(new ByteArrayInputStream(json.getBytes(StandardCharsets.ISO_8859_1)));
+
+    String result = converter.read(ResolvableType.forClass(String.class), inputMessage, Map.of());
+
+    assertEquals(json, result);
+  }
+
+  @Test
+  void read_withNoContentType_defaultsToUtf8() throws IOException {
+    String json = "{\"key\":\"value\"}";
+    HttpHeaders headers = new HttpHeaders();
+    when(inputMessage.getHeaders()).thenReturn(headers);
+    when(inputMessage.getBody()).thenReturn(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)));
+
+    String result = converter.read(ResolvableType.forClass(String.class), inputMessage, Map.of());
+
+    assertEquals(json, result);
+  }
+
+  @Test
+  void read_withEmptyBody_returnsEmptyString() throws IOException {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    when(inputMessage.getHeaders()).thenReturn(headers);
+    when(inputMessage.getBody()).thenReturn(new ByteArrayInputStream(new byte[0]));
+
+    String result = converter.read(ResolvableType.forClass(String.class), inputMessage, Map.of());
+
+    assertEquals("", result);
+  }
+
+  @Test
+  void write_withUtf8ContentType_writesCorrectBytes() throws IOException {
+    String value = "{\"key\":\"value\"}";
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    when(outputMessage.getBody()).thenReturn(outputStream);
+
+    converter.write(value, ResolvableType.forClass(String.class), MediaType.APPLICATION_JSON, outputMessage, Map.of());
+
+    assertEquals(value, outputStream.toString(StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void write_withNullContentType_defaultsToUtf8() throws IOException {
+    String value = "{\"key\":\"value\"}";
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    when(outputMessage.getBody()).thenReturn(outputStream);
+
+    converter.write(value, ResolvableType.forClass(String.class), null, outputMessage, Map.of());
+
+    assertEquals(value, outputStream.toString(StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void write_withExplicitCharset_usesSpecifiedCharset() throws IOException {
+    String value = "{\"key\":\"ñ\"}";
+    MediaType mediaType = new MediaType("application", "json", StandardCharsets.ISO_8859_1);
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    when(outputMessage.getBody()).thenReturn(outputStream);
+
+    converter.write(value, ResolvableType.forClass(String.class), mediaType, outputMessage, Map.of());
+
+    assertEquals(value, outputStream.toString(StandardCharsets.ISO_8859_1));
+  }
+
+  @Test
+  void read_preservesJsonWhitespaceAndFormatting() throws IOException {
+    String json = "{\n  \"key\" : \"value\",\n  \"nested\" : { \"a\" : 1 }\n}";
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    when(inputMessage.getHeaders()).thenReturn(headers);
+    when(inputMessage.getBody()).thenReturn(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)));
+
+    String result = converter.read(ResolvableType.forClass(String.class), inputMessage, Map.of());
+
+    assertEquals(json, result);
+  }
+}

--- a/src/test/java/org/folio/edge/controller/InnReachProxyControllerTest.java
+++ b/src/test/java/org/folio/edge/controller/InnReachProxyControllerTest.java
@@ -2,6 +2,7 @@ package org.folio.edge.controller;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
@@ -50,6 +51,7 @@ class InnReachProxyControllerTest extends BaseControllerTest {
   private static final String BASE_URI = "/innreach/v2";
   private static final UrlPattern LOGIN_URL_PATTERN = urlEqualTo("/authn/login");
   private static final UrlPattern PATRON_VERIFY_URL_PATTERN = urlEqualTo("/inn-reach/d2ir/circ/verifypatron");
+  private static final UrlPattern PATRON_HOLD_URL_PATTERN = urlEqualTo("/inn-reach/d2ir/circ/patronhold/tracking01/d2irm");
 
   private static final String TEST_JWT_SIGNATURE_SECRET = "test-jwt-secret-for-hs256-algo!!";
   private static final SecretKey TEST_JWT_SECRET_KEY = Keys.hmacShaKeyFor(
@@ -140,6 +142,37 @@ class InnReachProxyControllerTest extends BaseControllerTest {
       .andExpect(status().isBadRequest())
       .andExpect(jsonPath("$.status").value("failed"))
       .andExpect(jsonPath("$.reason").value("Plain text error msg"));
+  }
+
+  @Test
+  void shouldForwardRequestBodyAsRawJson() throws Exception {
+    var httpHeaders = createInnReachHttpHeaders();
+    httpHeaders.set(AUTHORIZATION, AUTH_TOKEN_VALUE);
+
+    var requestBody = """
+        {
+          "pickupLocation": "API:API:APIDeliveryStop",
+          "centralItemType": 205,
+          "title": "Test1 inn-reach virtual031",
+          "author": "Virtual Author1",
+          "patronId": "tmivzhx3cvgbvb5taiat3elwgm"
+        }
+        """;
+
+    wireMock.stubFor(WireMock.post(PATRON_HOLD_URL_PATTERN)
+      .willReturn(aResponse().withBody("{}")
+        .withStatus(OK.value())
+        .withHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)));
+
+    mockMvc.perform(post(BASE_URI + "/circ/patronhold/tracking01/d2irm")
+        .headers(httpHeaders)
+        .contentType(APPLICATION_JSON_VALUE)
+        .content(requestBody))
+      .andExpect(status().isOk());
+
+    // Verify the body was forwarded as a raw JSON object, not double-encoded as a JSON string
+    wireMock.verify(postRequestedFor(PATRON_HOLD_URL_PATTERN)
+      .withRequestBody(equalToJson(requestBody)));
   }
 
 }


### PR DESCRIPTION
### Purpose
Replace the interim StringHttpMessageConverter workaround with a proper RawJsonStringHttpMessageConverter (ported from mod-inn-reach), which implements SmartHttpMessageConverter<String> — the correct Spring 7 contract for custom converters.

### Approach
The previous fix solved the double-encoding issue but used StringHttpMessageConverter with manually overridden supportedMediaTypes, which is brittle and relies on undocumented ordering behavior. The new RawJsonStringHttpMessageConverter explicitly implements canRead/canWrite checks for String type with application/json, and writes bytes directly to the output stream without any Jackson involvement. Registered via configureMessageConvertersList(converters -> converters.addFirst(...)) — consistent with the pattern already used in mod-inn-reach.

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[EDGINREACH-98](https://folio-org.atlassian.net/browse/EDGINREACH-98)
_List any Jira issues related to this pull request._

### Learning and Resources (if applicable)
_Discuss any research conducted during the development of this pull request. Include links to relevant blog posts, patterns, libraries, or addons that were used to solve the problem._

### Screenshots (if applicable)
_If this pull request involves any visual changes or new features, consider including screenshots or GIFs to illustrate the changes._
